### PR TITLE
Enforce Lite scene limit and surface UI messaging

### DIFF
--- a/admin/templates/dashboard.php
+++ b/admin/templates/dashboard.php
@@ -266,19 +266,32 @@ $tours = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}vortex360_tours ORDER 
                         </div>
 
                         <!-- Scenes Management -->
+                        <?php
+                        $scene_limit = 5;
+                        $scene_count = count($scenes);
+                        $scene_limit_reached = $scene_count >= $scene_limit;
+                        ?>
+
                         <div class="vortex360-editor-section">
                             <div class="vortex360-section-header">
                                 <h3 class="vortex360-section-title">
                                     <span class="dashicons dashicons-format-gallery"></span>
-                                    Scenes (<?php echo count($scenes); ?>)
+                                    Scenes (<?php echo $scene_count; ?>)
                                 </h3>
-                                
-                                <button class="vortex360-btn vortex360-btn-primary vortex360-add-scene" data-tour-id="<?php echo $tour->id; ?>">
+
+                                <button class="vortex360-btn vortex360-btn-primary vortex360-add-scene" data-tour-id="<?php echo $tour->id; ?>" <?php disabled($scene_limit_reached); ?> aria-disabled="<?php echo $scene_limit_reached ? 'true' : 'false'; ?>">
                                     <span class="dashicons dashicons-plus-alt"></span>
                                     Add Scene
                                 </button>
                             </div>
-                            
+
+                            <p class="vortex360-section-description">
+                                <?php printf(esc_html__('Vortex360 Lite supports up to %d scenes per tour.', 'vortex360-lite'), $scene_limit); ?>
+                                <?php if ($scene_limit_reached): ?>
+                                    <span class="vortex360-limit-warning"><?php esc_html_e('Scene limit reached. Delete an existing scene to add another.', 'vortex360-lite'); ?></span>
+                                <?php endif; ?>
+                            </p>
+
                             <?php if (empty($scenes)): ?>
                                 <div class="vortex360-empty-state">
                                     <div class="vortex360-empty-icon">📷</div>


### PR DESCRIPTION
### **User description**
## Summary
- stop scene creation when a tour already has five scenes and return a consistent Lite limit error payload
- mirror the new Lite limit guard in the AJAX scene creation endpoint so the UI receives the same response
- surface the five-scene Lite cap inside the dashboard and disable the add button once the limit is reached

## Testing
- php -l includes/class-scene.php
- php -l admin/templates/dashboard.php

------
https://chatgpt.com/codex/tasks/task_e_68ca2982c6c88333963a4f2e779a6bd7


___

### **PR Type**
Enhancement


___

### **Description**
- Enforce 5-scene limit for Lite version

- Add UI messaging and disable button when limit reached

- Standardize error responses across endpoints


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Scene Creation Request"] --> B["Check Scene Count"]
  B --> C{Count >= 5?}
  C -->|Yes| D["Return Limit Error"]
  C -->|No| E["Create Scene"]
  F["Dashboard UI"] --> G["Display Scene Count"]
  G --> H{Limit Reached?}
  H -->|Yes| I["Disable Add Button"]
  H -->|No| J["Enable Add Button"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dashboard.php</strong><dd><code>Add scene limit UI controls and messaging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

admin/templates/dashboard.php

<ul><li>Add scene count variables and limit checking logic<br> <li> Display scene limit messaging to users<br> <li> Disable add scene button when limit reached<br> <li> Show warning message when at scene limit</ul>


</details>


  </td>
  <td><a href="https://github.com/umarmf343/VORTEX-LITE-TRAE/pull/1/files#diff-5a80c26ba97b0b4487a663db4dc4e9c6c0ae8b8f133ea32072958919b042ebf6">+17/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>class-scene.php</strong><dd><code>Implement scene limit enforcement and error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

includes/class-scene.php

<ul><li>Add scene limit validation in <code>create_scene()</code> method<br> <li> Create standardized <code>get_scene_limit_error()</code> helper method<br> <li> Add scene limit check in AJAX endpoint<br> <li> Optimize scene count retrieval to avoid duplicate calls</ul>


</details>


  </td>
  <td><a href="https://github.com/umarmf343/VORTEX-LITE-TRAE/pull/1/files#diff-91830b33f86f4fd00910499ab3f4965a076768d4da02f80d61e1436787300499">+30/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

