### PR TITLE
Enforce Lite hotspot limits and sanitize hotspot types

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -515,19 +515,44 @@ class Vortex360_Lite_Admin {
         
         if ($hotspot_id) {
             $result = $hotspot_manager->update_hotspot($hotspot_id, $hotspot_data);
-        } else {
-            $result = $hotspot_manager->create_hotspot($hotspot_data);
-            $hotspot_id = $result;
-        }
-        
-        if ($result) {
+
+            if (is_array($result) && empty($result['success'])) {
+                wp_send_json_error($result);
+            }
+
+            if ($result === false) {
+                wp_send_json_error('Failed to save hotspot');
+            }
+
             wp_send_json_success(array(
                 'hotspot_id' => $hotspot_id,
                 'message' => 'Hotspot saved successfully'
             ));
-        } else {
+        }
+
+        $creation = $hotspot_manager->create_hotspot($hotspot_data);
+
+        if (is_array($creation)) {
+            if (empty($creation['success'])) {
+                wp_send_json_error($creation);
+            }
+
+            $hotspot_id = $creation['data']['id'] ?? 0;
+
+            wp_send_json_success(array(
+                'hotspot_id' => $hotspot_id,
+                'message' => $creation['data']['message'] ?? 'Hotspot saved successfully'
+            ));
+        }
+
+        if ($creation === false) {
             wp_send_json_error('Failed to save hotspot');
         }
+
+        wp_send_json_success(array(
+            'hotspot_id' => absint($creation),
+            'message' => 'Hotspot saved successfully'
+        ));
     }
     
     /**

--- a/admin/class-vx-admin.php
+++ b/admin/class-vx-admin.php
@@ -315,7 +315,10 @@ class VX_Admin {
                         'confirmRemoveScene' => __('Are you sure you want to remove this scene?', 'vortex360-lite'),
                         'confirmRemoveHotspot' => __('Are you sure you want to remove this hotspot?', 'vortex360-lite'),
                         'maxScenesReached' => __('Maximum number of scenes reached for Lite version.', 'vortex360-lite'),
-                        'maxHotspotsReached' => __('Maximum number of hotspots reached for this scene.', 'vortex360-lite'),
+                        'maxHotspotsReached' => sprintf(
+                            __('You\'ve reached the Lite limit of %d hotspots for this scene. Upgrade to Pro for unlimited hotspots.', 'vortex360-lite'),
+                            vx_get_lite_limits()['max_hotspots_per_scene']
+                        ),
                         'upgradePrompt' => __('Upgrade to Pro for unlimited scenes and hotspots.', 'vortex360-lite')
                     )
                 ));

--- a/includes/class-database.php
+++ b/includes/class-database.php
@@ -297,16 +297,29 @@ class Vortex360_Lite_Database {
      * @return array Sanitized data array
      */
     public function sanitize_hotspot_data($data) {
+        $type = strtolower($data['type'] ?? 'info');
+        $allowed_types = array('info', 'link', 'image');
+
+        if (!in_array($type, $allowed_types, true)) {
+            $type = 'info';
+        }
+
+        if ($type === 'info') {
+            $normalized_type = 'text';
+        } elseif ($type === 'link') {
+            $normalized_type = 'url';
+        } else {
+            $normalized_type = $type;
+        }
+
         return array(
             'scene_id' => absint($data['scene_id'] ?? 0),
-            'type' => in_array($data['type'] ?? 'info', 
-                              ['info', 'scene', 'url', 'image', 'video']) 
-                     ? $data['type'] : 'info',
+            'type' => $normalized_type,
             'title' => sanitize_text_field($data['title'] ?? ''),
             'content' => wp_kses_post($data['content'] ?? ''),
-            'target_scene_id' => !empty($data['target_scene_id']) 
+            'target_scene_id' => !empty($data['target_scene_id'])
                                 ? absint($data['target_scene_id']) : null,
-            'target_url' => !empty($data['target_url']) 
+            'target_url' => !empty($data['target_url'])
                            ? esc_url_raw($data['target_url']) : null,
             'media_url' => !empty($data['media_url']) 
                           ? esc_url_raw($data['media_url']) : null,


### PR DESCRIPTION
### **User description**
## Summary
- enforce the Lite per-scene hotspot ceiling with a reusable count helper and localized feedback
- normalize hotspot sanitization to accept only info/link/image inputs while mapping info to text storage for compatibility
- update admin AJAX responses and UI strings so creators see friendly limit messaging when the cap is reached

## Testing
- php -l includes/class-hotspot.php
- php -l includes/class-database.php
- php -l admin/class-admin.php
- php -l admin/class-vx-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68ca293898648333b566cdd3fb5d97fa


___

### **PR Type**
Enhancement


___

### **Description**
- Enforce Lite version hotspot limits per scene

- Sanitize hotspot types to accept only info/link/image

- Improve AJAX error handling and user feedback

- Add hotspot count helper method


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hotspot Creation Request"] --> B["Check Hotspot Count"]
  B --> C{"Limit Reached?"}
  C -->|Yes| D["Return Error Message"]
  C -->|No| E["Sanitize Type"]
  E --> F["Create Hotspot"]
  F --> G["Success Response"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>class-admin.php</strong><dd><code>Enhanced AJAX hotspot save error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

admin/class-admin.php

<ul><li>Enhanced AJAX hotspot save handler with better error handling<br> <li> Added support for array responses from hotspot manager<br> <li> Improved success/error message handling for creation and updates</ul>


</details>


  </td>
  <td><a href="https://github.com/umarmf343/VORTEX-LITE-TRAE/pull/3/files#diff-04431c910a832ed347d95798fed2aff245c7c2a55216b2cec706ffae3939cc1b">+32/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>class-vx-admin.php</strong><dd><code>Improved hotspot limit messaging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

admin/class-vx-admin.php

<ul><li>Updated hotspot limit message to include dynamic count<br> <li> Added sprintf formatting for user-friendly limit messaging</ul>


</details>


  </td>
  <td><a href="https://github.com/umarmf343/VORTEX-LITE-TRAE/pull/3/files#diff-ad7fcdba85784f45492c4b0c2b7d0323cd1fd2ca5333ddb98d27003ddd57f0b2">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>class-database.php</strong><dd><code>Sanitized and normalized hotspot types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

includes/class-database.php

<ul><li>Restricted hotspot types to info/link/image only<br> <li> Added type normalization mapping info to text and link to url<br> <li> Improved type validation with strict comparison</ul>


</details>


  </td>
  <td><a href="https://github.com/umarmf343/VORTEX-LITE-TRAE/pull/3/files#diff-ed8c7404d78708e37392f8cb54a906e47505f6337edb342050e7cfea87653e14">+18/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>class-hotspot.php</strong><dd><code>Added hotspot limits and type validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

includes/class-hotspot.php

<ul><li>Added hotspot count limit enforcement for Lite version<br> <li> Restricted valid hotspot types to info/link/image<br> <li> Added <code>get_hotspot_count()</code> helper method<br> <li> Implemented type mapping between frontend and database formats</ul>


</details>


  </td>
  <td><a href="https://github.com/umarmf343/VORTEX-LITE-TRAE/pull/3/files#diff-b5c775d4fd1ad389e4f655cb8d2ffdb3a755a782b6e2d821221e61355dc4ad8e">+69/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

