### PR TITLE
Conditionally load editor integrations

### DIFF
--- a/blocks/class-vx-gutenberg-block.php
+++ b/blocks/class-vx-gutenberg-block.php
@@ -11,12 +11,32 @@ if (!defined('ABSPATH')) {
 }
 
 class VX_Gutenberg_Block {
+
+    /**
+     * Single instance of the Gutenberg block bootstrap.
+     *
+     * @var VX_Gutenberg_Block|null
+     */
+    private static $instance = null;
     
     /**
      * Constructor
      */
-    public function __construct() {
+    private function __construct() {
         $this->init_hooks();
+    }
+
+    /**
+     * Get the singleton instance.
+     *
+     * @return VX_Gutenberg_Block
+     */
+    public static function instance() {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
     }
     
     /**
@@ -358,9 +378,11 @@ class VX_Gutenberg_Block {
     }
 }
 
-// Initialize the Gutenberg block
-new VX_Gutenberg_Block();
+// Initialize the Gutenberg block when block APIs are available
+if (function_exists('register_block_type')) {
+    $vx_gutenberg_block = VX_Gutenberg_Block::instance();
 
-// Add AJAX handlers
-add_action('wp_ajax_vx_get_tour_preview', array('VX_Gutenberg_Block', 'ajax_get_tour_preview'));
-add_action('wp_ajax_nopriv_vx_get_tour_preview', array('VX_Gutenberg_Block', 'ajax_get_tour_preview'));
+    // Add AJAX handlers
+    add_action('wp_ajax_vx_get_tour_preview', array($vx_gutenberg_block, 'ajax_get_tour_preview'));
+    add_action('wp_ajax_nopriv_vx_get_tour_preview', array($vx_gutenberg_block, 'ajax_get_tour_preview'));
+}

--- a/elementor/class-vx-elementor-integration.php
+++ b/elementor/class-vx-elementor-integration.php
@@ -11,12 +11,32 @@ if (!defined('ABSPATH')) {
 }
 
 class VX_Elementor_Integration {
+
+    /**
+     * Holds the single instance of the integration.
+     *
+     * @var VX_Elementor_Integration|null
+     */
+    private static $instance = null;
     
     /**
      * Constructor
      */
-    public function __construct() {
+    private function __construct() {
         $this->init_hooks();
+    }
+
+    /**
+     * Retrieve the singleton instance.
+     *
+     * @return VX_Elementor_Integration
+     */
+    public static function instance() {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
     }
     
     /**
@@ -34,7 +54,7 @@ class VX_Elementor_Integration {
      * Check if Elementor is active
      */
     public static function is_elementor_active() {
-        return did_action('elementor/loaded');
+        return did_action('elementor/loaded') || class_exists('\\Elementor\\Plugin');
     }
     
     /**
@@ -366,10 +386,16 @@ class VX_Elementor_Integration {
     }
 }
 
-// Initialize Elementor integration if Elementor is active
-if (VX_Elementor_Integration::is_elementor_active()) {
-    new VX_Elementor_Integration();
-    
+// Initialize Elementor integration when Elementor is ready
+$vx_elementor_bootstrap = static function () {
+    VX_Elementor_Integration::instance();
+
     // Add Elementor support to tour post type
     add_action('init', array('VX_Elementor_Integration', 'add_elementor_support'), 20);
+};
+
+if (did_action('elementor/loaded')) {
+    $vx_elementor_bootstrap();
+} else {
+    add_action('elementor/loaded', $vx_elementor_bootstrap);
 }

--- a/includes/class-vx.php
+++ b/includes/class-vx.php
@@ -159,6 +159,41 @@ class VX {
         require_once plugin_dir_path(dirname(__FILE__)) . 'includes/class-vx-shortcode.php';
         require_once plugin_dir_path(dirname(__FILE__)) . 'includes/class-vx-rest.php';
 
+        $plugin_base_path = plugin_dir_path(dirname(__FILE__));
+
+        $gutenberg_block_file = $plugin_base_path . 'blocks/class-vx-gutenberg-block.php';
+        if (file_exists($gutenberg_block_file)) {
+            if (function_exists('register_block_type')) {
+                require_once $gutenberg_block_file;
+            } else {
+                add_action(
+                    'init',
+                    static function () use ($gutenberg_block_file) {
+                        if (function_exists('register_block_type') && file_exists($gutenberg_block_file)) {
+                            require_once $gutenberg_block_file;
+                        }
+                    },
+                    5
+                );
+            }
+        }
+
+        $elementor_integration_file = $plugin_base_path . 'elementor/class-vx-elementor-integration.php';
+        if (file_exists($elementor_integration_file)) {
+            if (did_action('elementor/loaded') || class_exists('\\Elementor\\Plugin')) {
+                require_once $elementor_integration_file;
+            } else {
+                add_action(
+                    'elementor/loaded',
+                    static function () use ($elementor_integration_file) {
+                        if (file_exists($elementor_integration_file)) {
+                            require_once $elementor_integration_file;
+                        }
+                    }
+                );
+            }
+        }
+
         $this->loader = new VX_Loader();
     }
 


### PR DESCRIPTION
### **User description**
## Summary
- load the Gutenberg block and Elementor integration only when their respective APIs are available to avoid fatal errors when the editors are disabled
- wrap the Gutenberg block and Elementor integration bootstraps in singleton guards so they instantiate once and safely register AJAX handlers and hooks

## Testing
- php -l includes/class-vx.php
- php -l blocks/class-vx-gutenberg-block.php
- php -l elementor/class-vx-elementor-integration.php

------
https://chatgpt.com/codex/tasks/task_e_68ca284089e08333bb495bcc9a6054c1


___

### **PR Type**
Enhancement


___

### **Description**
- Implement conditional loading for Gutenberg and Elementor integrations

- Add singleton pattern to prevent multiple instantiations

- Wrap editor integrations with API availability checks

- Improve error handling for missing editor dependencies


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Main Plugin"] --> B["Check Gutenberg API"]
  A --> C["Check Elementor API"]
  B --> D["Load Gutenberg Block"]
  C --> E["Load Elementor Integration"]
  D --> F["Singleton Instance"]
  E --> G["Singleton Instance"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>class-vx.php</strong><dd><code>Conditional loading for editor integrations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

includes/class-vx.php

<ul><li>Add conditional loading logic for Gutenberg and Elementor files<br> <li> Check for API availability before requiring integration files<br> <li> Implement deferred loading with action hooks when APIs not ready<br> <li> Add file existence checks for robustness</ul>


</details>


  </td>
  <td><a href="https://github.com/umarmf343/VORTEX-LITE-TRAE/pull/4/files#diff-d0a43d5b4bb62b9cb8f437181c24071ee11cef954110f327bb1b6fc8a4e82b4c">+35/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>class-vx-gutenberg-block.php</strong><dd><code>Singleton pattern for Gutenberg block</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

blocks/class-vx-gutenberg-block.php

<ul><li>Convert to singleton pattern with private constructor<br> <li> Add <code>instance()</code> method for singleton access<br> <li> Wrap initialization in <code>register_block_type</code> function check<br> <li> Update AJAX handler registration to use instance</ul>


</details>


  </td>
  <td><a href="https://github.com/umarmf343/VORTEX-LITE-TRAE/pull/4/files#diff-7f053a901e9dc87392ebfa3475df87ec461f690378cd7cf74b5d74db9396d5af">+28/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>class-vx-elementor-integration.php</strong><dd><code>Singleton pattern for Elementor integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

elementor/class-vx-elementor-integration.php

<ul><li>Implement singleton pattern with private constructor<br> <li> Add <code>instance()</code> method for controlled instantiation<br> <li> Improve Elementor detection with additional class check<br> <li> Use closure-based bootstrap with deferred loading</ul>


</details>


  </td>
  <td><a href="https://github.com/umarmf343/VORTEX-LITE-TRAE/pull/4/files#diff-5a01e40120629c0f7d37e726aab39ccd69041aa487497d5efed8073d75bd7785">+33/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

