### PR TITLE
Allow moving scenes and hotspots and validate JSON settings

### DIFF
--- a/includes/class-database.php
+++ b/includes/class-database.php
@@ -318,13 +318,31 @@ class Vortex360_Lite_Database {
             'yaw' => floatval($data['yaw'] ?? 0),
             'css_class' => sanitize_html_class($data['css_class'] ?? ''),
             'icon' => sanitize_text_field($data['icon'] ?? ''),
-            'settings' => is_array($data['settings'] ?? null)
-                ? wp_json_encode($data['settings'])
-                : ((is_string($data['settings'] ?? null) && $data['settings'] !== '')
-                    ? wp_kses_post($data['settings'])
-                    : '{}'),
+            'settings' => $this->sanitize_settings_field($data['settings'] ?? null),
             'is_active' => (bool) ($data['is_active'] ?? true)
         );
+    }
+
+    /**
+     * Ensure settings data is stored as a valid JSON string.
+     *
+     * @param mixed $settings Raw settings value.
+     * @return string
+     */
+    private function sanitize_settings_field($settings) {
+        if (is_array($settings)) {
+            return wp_json_encode($settings);
+        }
+
+        if (is_string($settings) && $settings !== '') {
+            json_decode($settings);
+
+            if (JSON_ERROR_NONE === json_last_error()) {
+                return $settings;
+            }
+        }
+
+        return '{}';
     }
 
     /**

--- a/includes/class-hotspot.php
+++ b/includes/class-hotspot.php
@@ -207,8 +207,9 @@ class Vortex360_Lite_Hotspot {
         // Sanitize data
         $sanitized_data = $this->database->sanitize_hotspot_data($data);
 
-        // Remove scene_id from update data (shouldn't be changed)
-        unset($sanitized_data['scene_id']);
+        if (!array_key_exists('scene_id', $data)) {
+            unset($sanitized_data['scene_id']);
+        }
         
         // Update database
         $table_name = $wpdb->prefix . 'vortex360_hotspots';

--- a/includes/class-scene.php
+++ b/includes/class-scene.php
@@ -177,8 +177,9 @@ class Vortex360_Lite_Scene {
         // Sanitize data
         $sanitized_data = $this->database->sanitize_scene_data($data);
 
-        // Remove tour_id from update data (shouldn't be changed)
-        unset($sanitized_data['tour_id']);
+        if (!array_key_exists('tour_id', $data)) {
+            unset($sanitized_data['tour_id']);
+        }
         
         // Update database
         $table_name = $wpdb->prefix . 'vortex360_scenes';


### PR DESCRIPTION
### **User description**
## Summary
- allow scene and hotspot moves by keeping provided tour_id and scene_id data during updates
- retain current associations when IDs are not supplied by checking the incoming payload
- guard hotspot settings against JSON corruption by validating strings before saving

## Testing
- php -l includes/class-hotspot.php
- php -l includes/class-scene.php
- php -l includes/class-database.php

------
https://chatgpt.com/codex/tasks/task_e_68ca8f9cca0883339102e5003179ee75


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Allow moving scenes and hotspots between tours/scenes

- Add JSON validation for hotspot settings field

- Prevent data corruption with proper sanitization


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Update Request"] --> B["Check for tour_id/scene_id"]
  B --> C["Conditional ID Preservation"]
  C --> D["JSON Settings Validation"]
  D --> E["Database Update"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>class-database.php</strong><dd><code>Add JSON validation for settings field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

includes/class-database.php

<ul><li>Extract settings sanitization into dedicated method<br> <li> Add JSON validation before storing settings data<br> <li> Return empty JSON object for invalid settings</ul>


</details>


  </td>
  <td><a href="https://github.com/umarmf343/VORTEX-LITE-TRAE/pull/8/files#diff-ed8c7404d78708e37392f8cb54a906e47505f6337edb342050e7cfea87653e14">+23/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>class-hotspot.php</strong><dd><code>Enable hotspot movement between scenes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

includes/class-hotspot.php

<ul><li>Allow <code>scene_id</code> updates when explicitly provided<br> <li> Only remove <code>scene_id</code> if not present in input data</ul>


</details>


  </td>
  <td><a href="https://github.com/umarmf343/VORTEX-LITE-TRAE/pull/8/files#diff-b5c775d4fd1ad389e4f655cb8d2ffdb3a755a782b6e2d821221e61355dc4ad8e">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>class-scene.php</strong><dd><code>Enable scene movement between tours</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

includes/class-scene.php

<ul><li>Allow <code>tour_id</code> updates when explicitly provided<br> <li> Only remove <code>tour_id</code> if not present in input data</ul>


</details>


  </td>
  <td><a href="https://github.com/umarmf343/VORTEX-LITE-TRAE/pull/8/files#diff-91830b33f86f4fd00910499ab3f4965a076768d4da02f80d61e1436787300499">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

